### PR TITLE
Run required checks on renovate branches

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,9 +2,8 @@ name: Gradle Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "renovate/*" ]
   pull_request:
-    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -3,6 +3,8 @@
 #
 name: Run Pitest
 on:
+  push:
+    branches: [ "renovate/*" ]
   pull_request:
 
 permissions:


### PR DESCRIPTION
This allows Renovate to see whether the checks will succeed before raising a PR, which is my preference for major version bumps.