### PR TITLE
Publish releases to GitHub Packages as well as GPP

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -34,7 +34,7 @@ jobs:
       uses: gradle/gradle-build-action@v3
 
     - name: Execute Gradle build
-      run: ./gradlew --info :buildSrc:check build
+      run: ./gradlew :buildSrc:check build
 
     - name: Publish to GitHub Packages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,12 @@ jobs:
       uses: gradle/gradle-build-action@v3
 
     - name: Execute Gradle publish
-      run: ./gradlew --info publishPlugins
+      run: ./gradlew publishPlugins
       env:
         GRADLE_PUBLISH_KEY: hBnkAIS8CiAqxp0aU0dZzoaeH6u2zC6t
         GRADLE_PUBLISH_SECRET: ${{secrets.gradle_publish_secret}}
+
+    - name: Publish to GitHub Packages
+      run: ./gradlew publish
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Also, we don't need verbose build logs at present.