### PR TITLE
Update the Gradle action to its new location

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 permissions:
-  contents: read
+  contents: write
   checks: write
   packages: write
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,17 +21,27 @@ jobs:
       with:
         fetch-depth: 0 # so we can work out our version correctly
 
-    - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
-
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 21
 
+    # A push will be from Renovate, so I can agree to the terms.
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v4
+      if: github.actor != 'andrewaylett' && github.event_name != 'push'
+      with:
+        dependency-graph: 'generate-and-submit'
+
+    - name: Setup Gradle Build Scan
+      uses: gradle/actions/setup-gradle@v4
+      if: github.actor == 'andrewaylett' || github.event_name == 'push'
+      with:
+        dependency-graph: 'generate-and-submit'
+        build-scan-publish: 'true'
+        build-scan-terms-of-use-agree: 'yes'
+        build-scan-terms-of-use-url: https://gradle.com/help/legal-terms-of-use
 
     - name: Execute Gradle build
       run: ./gradlew :buildSrc:check build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
+      uses: gradle/actions/wrapper-validation@v4
 
     - name: Set up JDK 21
       uses: actions/setup-java@v4
@@ -38,7 +38,7 @@ jobs:
         java-version: 21
 
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Execute Gradle build
       run: ./gradlew dokkaHtml --no-configuration-cache

--- a/.github/workflows/pitest.yml
+++ b/.github/workflows/pitest.yml
@@ -24,17 +24,24 @@ jobs:
       with:
         fetch-depth: 2
 
-    - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
-
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 21
 
+      # A push will be from Renovate, so I can agree to the terms.
     - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+      uses: gradle/actions/setup-gradle@v4
+      if: github.actor != 'andrewaylett' && github.event_name != 'push'
+
+    - name: Setup Gradle Build Scan
+      uses: gradle/actions/setup-gradle@v4
+      if: github.actor == 'andrewaylett' || github.event_name == 'push'
+      with:
+        build-scan-publish: 'true'
+        build-scan-terms-of-use-agree: 'yes'
+        build-scan-terms-of-use-url: https://gradle.com/help/legal-terms-of-use
 
     - name: Execute Pitest
       run: ./gradlew --no-configuration-cache pitest-github

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,17 +16,19 @@ jobs:
     - name: Check out
       uses: actions/checkout@v4
 
-    - name: Validate Gradle Wrapper
-      uses: gradle/wrapper-validation-action@v3
-
     - name: Set up JDK 21
       uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: 21
 
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v3
+    - name: Setup Gradle Build Scan
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        dependency-graph: 'generate-and-submit'
+        build-scan-publish: 'true'
+        build-scan-terms-of-use-agree: 'yes'
+        build-scan-terms-of-use-url: https://gradle.com/help/legal-terms-of-use
 
     - name: Execute Gradle publish
       run: ./gradlew publishPlugins

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [created]
 
 permissions:
-  contents: read
+  contents: write
   checks: write
   packages: write
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml
+.idea/kotlinc.xml
 .idea/libraries/
 *.iws
 *.iml

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20" />
-  </component>
-</project>


### PR DESCRIPTION
Also agree to Build Scan ToS for myself (and Renovate, which I configured) only.

Gradle wrapper validation is performed by the setup action by default, so I don't need to run it standalone.