### PR TITLE
Be a bit more selective about which JARs to publish

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,7 +48,7 @@ jobs:
 
     - name: Publish to GitHub Packages
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: ./gradlew publish
+      run: ./gradlew publishPluginMavenPublicationToGitHubPackagesRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,6 @@ jobs:
         GRADLE_PUBLISH_SECRET: ${{secrets.gradle_publish_secret}}
 
     - name: Publish to GitHub Packages
-      run: ./gradlew publish
+      run: ./gradlew publishPluginMavenPublicationToGitHubPackagesRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,11 @@ dependencies {
 group = "eu.aylett"
 version = aylett.versions.gitVersion()
 
+java {
+  withSourcesJar()
+  withJavadocJar()
+}
+
 val checkPublishVersion by tasks.registering {
   doNotTrackState("Either does nothing or fails the build")
   doFirst {


### PR DESCRIPTION
We want JavaDoc and Sources, we don't want marker packages for every plugin outside of the plugin portal.