### PR TITLE
Don't try to push non-release builds to OSSRH

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -52,14 +52,6 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Publish to OSSRH Snapshots
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: ./gradlew --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false publishPluginMavenPublicationToSonatypeRepository closeSonatypeStagingRepository
-      env:
-        OSSRH_TOKEN_USER: ${{ secrets.OSSRH_TOKEN_USER }}
-        OSSRH_TOKEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_PASSWORD }}
-        GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v5
       if: success() || failure() # always run even if the previous step fails


### PR DESCRIPTION
We don't want to release them, so we're just building up "closed" staging repositories that we don't need.