### PR TITLE
Disable the configuration cache for publishing

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -42,7 +42,7 @@ jobs:
 
     - name: Publish to GitHub Packages Snapshots
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: ./gradlew publishPluginMavenPublicationToGitHubPackagesRepository
+      run: ./gradlew --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false publishPluginMavenPublicationToGitHubPackagesRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
         GRADLE_PUBLISH_SECRET: ${{secrets.gradle_publish_secret}}
 
     - name: Publish to GitHub Packages Releases
-      run: ./gradlew publishPluginMavenPublicationToGitHubPackagesRepository
+      run: ./gradlew --no-configuration-cache -Dorg.gradle.unsafe.isolated-projects=false publishPluginMavenPublicationToGitHubPackagesRepository
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,13 +66,6 @@ java {
   }
 }
 
-if (gradle.taskGraph.hasTask(":generateMetadataFileForPluginMavenPublication")) {
-  // https://youtrack.jetbrains.com/issue/KT-79047/Gradle-compileKotlin-fails-with-configuration-cache
-  tasks.withType<org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile<*>> {
-    incremental = false
-  }
-}
-
 val checkPublishVersion by tasks.registering {
   doNotTrackState("Either does nothing or fails the build")
   doFirst {


### PR DESCRIPTION
Most publish steps disabled it already, add to the ones that didn't. And remove the workaround for the Kotlin bug, as it didn't work in GHA.