### PR TITLE
Add a dependency locking plugin

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,8 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="MemberVisibilityCanBePrivate" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PublicApiImplicitType" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PyCompatibilityInspection" enabled="false" level="WARNING" enabled_by_default="false">
       <option name="ourVersions">
         <value>
@@ -18,6 +20,7 @@
         </list>
       </option>
     </inspection_tool>
+    <inspection_tool class="ReplaceCollectionCountWithSize" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="ReplaceUntilWithRangeUntil" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
   </profile>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="1">
-      <item index="0" class="java.lang.String" itemvalue="org.junit.jupiter.api.BeforeAll" />
+    <list size="2">
+      <item index="0" class="java.lang.String" itemvalue="org.gradle.api.tasks.TaskAction" />
+      <item index="1" class="java.lang.String" itemvalue="org.junit.jupiter.api.BeforeAll" />
     </list>
+    <pattern value="org.gradle.api.Project" hierarchically="true" />
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/.license-header
+++ b/.license-header
@@ -1,4 +1,4 @@
-Copyright 2023 Andrew Aylett
+Copyright 2025 Andrew Aylett
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,88 @@ In an ideal world, absent any requirement to publish the build output, you need
 only apply my conventions plugin and you'll have a magically wonderful build
 experience.
 
+## Documentation
+
+[Documentation](https://gradle-plugins.aylett.eu) is automatically generated
+from the source code and [module.md](module.md)
+
 ## Applying the plugins
 
 If you're sure you agree with all my decisions, you may import the main
-conventions file into your `build.gradle.kts` or `build.gradle`.
+conventions plugin into your `plugins` block:
+
+Gradle Kotlin DSL:
+
+```kotlin
+plugins {
+  id("eu.aylett.conventions") version "<latest>"
+}
+```
+
+Groovy DSL:
+
+```groovy
+plugins {
+  id 'eu.aylett.conventions' version '<latest>'
+}
+```
+
+Common plugin IDs available from this project:
+- eu.aylett.conventions — apply all conventions.
+- eu.aylett.conventions.jvm — JVM build conventions (testing, integration tests, etc.).
+- eu.aylett.conventions.ide-support — IDE integration helpers.
+- eu.aylett.conventions.bom-alignment — virtual BOM alignment.
+- eu.aylett.plugins.version — sets version from the Git repository state.
+- eu.aylett.lock-dependencies — generate and enforce a versions.lock across the build.
 
 If you have a multi-project build, I recommend adding a `buildSrc` project with
-a plugin that configures the correct version of this plugin (along with and
-customisation, or extra configuration) then applying _that_ plugin to each of
+a plugin that pins the desired versions of these plugins (along with any
+customisation or extra configuration) and then applying that plugin to each of
 your projects.
 
-If you have multiple builds, and you want different conventions from me, you
-should probably do what I've done and publish your own conventions. My hope is
-that this project might be a useful base for people to start with.
+If you have multiple builds and want different conventions to mine, you should
+probably do what I've done and publish your own conventions. My hope is that
+this project might be a useful base for people to start with.
+
+### Dependency locking quickstart
+
+This repository ships a small plugin to help generate and enforce a lock file of
+dependency versions across your build.
+
+Single project (Groovy DSL):
+
+```groovy
+plugins {
+  id 'java'
+  id 'eu.aylett.lock-dependencies' version '<latest>'
+}
+
+repositories {
+  mavenCentral()
+}
+
+versionsLocks {
+    enableLockWriting()
+    extendAllConfigurations()
+}
+```
+
+Then run:
+
+```
+./gradlew writeVersionsLocks
+```
+
+This creates a `versions.lock` file at the root of the build. For a recommended
+multi-project setup with a platform project, see module.md.
+
+The format of the `versions.lock` file matches that used by Palantir's [gradle-consistent-versions](https://github.com/palantir/gradle-consistent-versions) plugin, but the implementation here is entirely new.
+The intent is that we can use tools (like Renovate) that understand the lock file format, but with code that's compatible with Gradle's isolated projects features.
+
+## Contributing and development
+
+- Build: `./gradlew build`
+- Run unit and functional tests: `./gradlew check`
+- Generate local documentation site: `./gradlew dokkaHtml` and open `build/dokka/html/index.html`
+
+This project is licensed under the Apache License 2.0, see LICENSE.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,8 +33,8 @@ plugins {
 }
 
 dependencies {
-  implementation(platform("org.jetbrains.kotlin:kotlin-bom:$embeddedKotlinVersion"))
   implementation("com.google.guava:guava:33.4.8-jre")
+  implementation(gradleApi())
 
   testImplementation("com.fasterxml.jackson.core:jackson-core:2.20.0")
   testImplementation("com.fasterxml.jackson.core:jackson-databind")
@@ -213,5 +213,13 @@ gradlePlugin {
     tags = listOf("conventions", "jvm")
     //language=jvm-class-name
     implementationClass = "eu.aylett.gradle.plugins.conventions.Conventions"
+  }
+  plugins.create("lock-dependencies") {
+    id = "eu.aylett.lock-dependencies"
+    displayName = "aylett.eu dependency locking plugin"
+    description = "Tools for managing dependency lock files"
+    tags = listOf("dependencies", "jvm", "locking")
+    //language=jvm-class-name
+    implementationClass = "eu.aylett.gradle.plugins.dependencies.DependencyLockPlugin"
   }
 }

--- a/module.md
+++ b/module.md
@@ -1,13 +1,114 @@
 # Module gradle-plugins
 
-This project provides Gradle Conventions for building JVM projects.
+This project provides Gradle Plugins and Conventions for building JVM projects.
 
 ## Getting Started
 
-Add the main conventions plugin to your build's plugins block:
+Add the [main conventions plugin](https://gradle-plugins.aylett.eu/gradle-plugins/eu.aylett.gradle.plugins.conventions/index.html) to your build's plugins block:
 
 ```kotlin
 plugins {
   id("eu.aylett.conventions") version "0.1.0"
 }
 ```
+
+## Dependency Locking
+
+This module ships a small plugin to help you generate and enforce a lock file of dependency versions across your build.
+
+- Plugin ID: `eu.aylett.lock-dependencies`
+- Task: `writeVersionsLocks` writes a `versions.lock` file at the root of the build
+- File format: each non-comment line is `group:artifact:version (…reason…)`, blank lines are allowed to reduce merge conflicts
+
+### Multi-project builds with a platform project
+
+In multi-project builds, the preferred workflow is to have a dedicated platform subproject that defines and enforces versions for the rest of the build.
+
+1) In all your non-platform projects, apply the plugin and declare a dependency on the platform project.  The easiest way to do this is using a convention plugin in `buildSrc`.
+
+    build.gradle (Groovy DSL):
+
+    ```groovy
+    plugins {
+        id 'java'
+        id 'eu.aylett.lock-dependencies' version '0.1.0'
+    }
+
+    dependencies {
+        implementation(platform(project(":platform")))
+    }
+    ```
+
+2) Create a `platform` subproject configured as a Java Platform and apply the lock plugin there.
+
+    platform/build.gradle (Groovy DSL):
+
+    ```groovy
+    plugins {
+        id 'java-platform'
+        id 'eu.aylett.lock-dependencies' version '0.1.0'
+    }
+    ```
+
+Notes:
+- On Java Platform projects, `writeVersionsLocks` is automatically enabled by the plugin. Running `./gradlew writeVersionsLocks` will generate/update the shared `versions.lock` file at the root of the build.
+- The plugin coordinates dependencies from other subprojects so the generated lock reflects the full set of external modules used across the build.
+ - For this reason, we use an unscoped call to the `writeVersionsLocks` task.  This ensures that every project is configured, so the service can ensure we collect dependencies from every project.
+- The platform project reads `versions.lock` and converts each entry into a constraint on its `api` configuration. Consumer projects then pull in those constraints via `implementation(platform(project(":platform")))`.
+
+### Updating dependencies
+
+You have two common ways to update versions:
+
+- Regenerate to latest resolved versions: simply run `./gradlew writeVersionsLocks`. The task resolves the current dependency graph and rewrites `versions.lock` entries accordingly.
+
+- Pin or bump a version explicitly: edit `versions.lock` by changing the right-hand version in the `group:artifact:version` triplet.  The note on reasons will be added if you re-lock.
+
+I recommend running `./gradlew writeVersionsLocks` from [pre-commit](https://pre-commit.com), to ensure it reflects the current state of the build.
+I recommend _not_ making the `check` task depend on `writeVersionsLocks`, or running it in CI unless you check that the resulting file is unchanged.
+
+Tips:
+- The write task is disabled by default on non-platform projects, you should not need to enable it if you're using a platform project.
+- The lock file lives at the root of the build (`versions.lock`) and is intended to be checked into version control.
+
+### Single project builds
+
+For a single project you can apply the plugin directly and run the write task when you want to (re)generate the lock file.
+
+This will be most useful if you're using a tool like Renovate to bump the versions in your lockfile.
+
+If you want to ensure that your dependencies resolve consistently, you should use [Gradle's own tooling](https://docs.gradle.org/current/userguide/dependency_resolution_consistency.html) for that, as shown below.
+
+build.gradle (Groovy DSL):
+
+```groovy
+plugins {
+    id 'java'
+    id 'eu.aylett.lock-dependencies' version '0.1.0'
+}
+
+repositories {
+    mavenCentral()
+}
+
+// To allow Renovate (or similar) to bump transitive dependencies
+versionsLocks {
+    enableLockWriting()
+    extendAllConfigurations()
+}
+
+// Ensure consistent resolution of versions across configurations
+java {
+    consistentResolution {
+        useCompileClasspathVersions()
+    }
+}
+```
+
+Then run:
+
+```
+./gradlew writeVersionsLocks
+```
+
+This will create a `versions.lock` file in the root project.  Non-empty lines not starting with `#` contain the resolved coordinates of all external dependencies on your classpath.

--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,22 @@
 {
-  "extends": [
-    "config:recommended",
-    "github>andrewaylett/renovate-config#v2",
-    ":assignAndReview(andrewaylett)"
-  ],
-    "maven": {
-        "managerFilePatterns": ["module.md"]
-    }
+    "extends": [
+        "config:recommended",
+        "github>andrewaylett/renovate-config#v2",
+        ":assignAndReview(andrewaylett)"
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "manager.md",
+                "README.md"
+            ],
+            "matchStrings": [
+                "id '(?<depName>[^']+)' version '(?<currentValue>[^']+)'",
+                "id\\(\"(?<depName>[^\"]+)\"\\) version \"(?<currentValue>[^\"]+)\""
+            ],
+            "packageNameTemplate": "eu.aylett:gradle-plugins",
+            "datasourceTemplate": "maven"
+        }
+    ]
 }

--- a/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/AbstractDependencyLockTest.kt
+++ b/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/AbstractDependencyLockTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.functionaltests.plugins.dependencies
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+abstract class AbstractDependencyLockTest {
+  @TempDir
+  lateinit var testProjectDir: File
+
+  val buildFile: File by lazy { File(testProjectDir, "build.gradle") }
+  val lockFile: File by lazy { testProjectDir.resolve("versions.lock") }
+  val lockFileLines: List<String> by lazy { lockFile.readLines() }
+  val lockEntries: List<String> by lazy {
+    lockFileLines.stream().filter { !it.startsWith("#") && !it.isBlank() }.toList()
+  }
+
+  val settingsFile: File by lazy { File(testProjectDir, "settings.gradle") }
+  val subprojectNames: MutableSet<String> = mutableSetOf()
+
+  lateinit var result: BuildResult
+
+  fun run(vararg args: String) {
+    if (subprojectNames.isNotEmpty()) {
+      settingsFile.writeText(
+        subprojectNames.joinToString("\n") { "include \":$it\"" },
+      )
+    }
+
+    result =
+      GradleRunner
+        .create()
+        .withProjectDir(testProjectDir)
+        .withArguments(*args, "--stacktrace")
+        .withPluginClasspath()
+        .build()
+  }
+
+  fun subproject(name: String): File {
+    subprojectNames.add(name)
+    val subprojectDir = File(testProjectDir, name)
+    subprojectDir.mkdirs()
+    return subprojectDir
+  }
+}

--- a/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/DependencyLockPluginFunctionalTest.kt
+++ b/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/DependencyLockPluginFunctionalTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.functionaltests.plugins.dependencies
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.not
+import org.hamcrest.io.FileMatchers.anExistingFile
+import org.junit.jupiter.api.Test
+
+class DependencyLockPluginFunctionalTest : AbstractDependencyLockTest() {
+  @Test
+  fun `can successfully apply the plugin and run its (skipped) task`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SKIPPED))
+    assertThat(lockFile, not(anExistingFile()))
+  }
+}

--- a/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/DependencyLockReadingFunctionalTest.kt
+++ b/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/DependencyLockReadingFunctionalTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.functionaltests.plugins.dependencies
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.`is`
+import org.junit.jupiter.api.Test
+
+class DependencyLockReadingFunctionalTest : AbstractDependencyLockTest() {
+  @Test
+  fun `can resolve a dependency within a single project`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      configurations.implementation.extendsFrom(configurations.lockConstraints)
+
+      dependencies {
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    lockFile.writeText(
+      """
+      # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+
+      eu.aylett:gradle-plugins:0.6.1 (requested)
+      """.trimIndent(),
+    )
+
+    run("dependencies", "--configuration", "compileClasspath")
+
+    assertThat(result.output, containsString("eu.aylett:gradle-plugins:0.5.2 -> 0.6.1"))
+    assertThat(result.task(":dependencies")!!.outcome, `is`(TaskOutcome.SUCCESS))
+  }
+
+  @Test
+  fun `can resolve a dependency within a single project using the extension`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      versionsLocks.extendAllConfigurations()
+
+      dependencies {
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    lockFile.writeText(
+      """
+      # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+
+      eu.aylett:gradle-plugins:0.6.1 (requested)
+      """.trimIndent(),
+    )
+
+    run("dependencies", "--configuration", "compileClasspath")
+
+    assertThat(result.output, containsString("eu.aylett:gradle-plugins:0.5.2 -> 0.6.1"))
+    assertThat(result.task(":dependencies")!!.outcome, `is`(TaskOutcome.SUCCESS))
+  }
+
+  @Test
+  fun `can resolve a dependency via a platform subproject`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation(platform(project(":platform")))
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    val platform = subproject("platform")
+
+    platform.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java-platform'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+      """.trimIndent(),
+    )
+
+    lockFile.writeText(
+      """
+      # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+
+      eu.aylett:gradle-plugins:0.6.1 (requested)
+      """.trimIndent(),
+    )
+
+    run("dependencies", "--configuration", "compileClasspath")
+
+    assertThat(result.output, containsString("eu.aylett:gradle-plugins:0.5.2 -> 0.6.1"))
+    assertThat(result.task(":dependencies")!!.outcome, `is`(TaskOutcome.SUCCESS))
+  }
+
+  @Test
+  fun `can resolve a dependency via a sibling platform subproject`() {
+    val buildProject = subproject("build")
+    buildProject.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation(platform(project(":platform")))
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    val platform = subproject("platform")
+
+    platform.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java-platform'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+      """.trimIndent(),
+    )
+
+    lockFile.writeText(
+      """
+      # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+
+      eu.aylett:gradle-plugins:0.6.1 (requested)
+      """.trimIndent(),
+    )
+
+    run(":build:dependencies", "--configuration", "compileClasspath")
+
+    assertThat(result.output, containsString("eu.aylett:gradle-plugins:0.5.2 -> 0.6.1"))
+    assertThat(result.task(":build:dependencies")!!.outcome, `is`(TaskOutcome.SUCCESS))
+  }
+}

--- a/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/DependencyLockWritingFunctionalTest.kt
+++ b/src/functionalTest/kotlin/eu/aylett/gradle/functionaltests/plugins/dependencies/DependencyLockWritingFunctionalTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.functionaltests.plugins.dependencies
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.startsWith
+import org.hamcrest.io.FileMatchers.anExistingFile
+import org.junit.jupiter.api.Test
+
+class DependencyLockWritingFunctionalTest : AbstractDependencyLockTest() {
+  @Test
+  fun `can successfully apply the plugin and run its (not skipped) task`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      tasks.named("writeVersionsLocks") {
+        enabled = true
+      }
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+    assertThat(lockEntries, empty())
+  }
+
+  @Test
+  fun `use the extension to enable lock file writing`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      versionsLocks.enableLockWriting()
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+    assertThat(lockEntries, empty())
+  }
+
+  @Test
+  fun `can successfully write a lockfile with a dependency that has no transitive dependencies`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation("org.springframework:spring-jcl:5.3.20")
+      }
+
+      tasks.named("writeVersionsLocks") {
+        enabled = true
+      }
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+    assertThat(lockEntries, hasSize(1))
+    assertThat(lockEntries.first(), startsWith("org.springframework:spring-jcl:5.3.20"))
+  }
+
+  @Test
+  fun `can write a lockfile with a dependency that has some transitive dependencies`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+
+      tasks.named("writeVersionsLocks") {
+        enabled = true
+      }
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+
+    val expected =
+      listOf(
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.errorprone:error_prone_annotations:2.36.0",
+        "com.google.guava:failureaccess:1.0.2",
+        "com.google.guava:guava:33.4.0-jre",
+        "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+        "com.google.j2objc:j2objc-annotations:3.0.0",
+        "eu.aylett:gradle-plugins:0.5.2",
+        "org.checkerframework:checker-qual:3.43.0",
+        "org.jetbrains.kotlin:kotlin-bom:2.0.20",
+      )
+    assertThat(lockEntries, contains(expected.map { startsWith(it) }))
+  }
+
+  @Test
+  fun `can write dependencies via a platform subproject`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation(platform(project(":platform")))
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    val platform = subproject("platform")
+
+    platform.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java-platform'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":platform:writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+
+    val expected =
+      listOf(
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.errorprone:error_prone_annotations:2.36.0",
+        "com.google.guava:failureaccess:1.0.2",
+        "com.google.guava:guava:33.4.0-jre",
+        "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+        "com.google.j2objc:j2objc-annotations:3.0.0",
+        "eu.aylett:gradle-plugins:0.5.2",
+        "org.checkerframework:checker-qual:3.43.0",
+        "org.jetbrains.kotlin:kotlin-bom:2.0.20",
+      )
+    assertThat(lockEntries, contains(expected.map { startsWith(it) }))
+  }
+
+  @Test
+  fun `can update dependencies via a platform subproject`() {
+    buildFile.writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation(platform(project(":platform")))
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    val platform = subproject("platform")
+
+    platform.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java-platform'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+      """.trimIndent(),
+    )
+
+    platform.resolve("versions.lock").writeText(
+      """
+      # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+
+      eu.aylett:gradle-plugins:0.4.0 (requested)
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":platform:writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+
+    val expected =
+      listOf(
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.errorprone:error_prone_annotations:2.36.0",
+        "com.google.guava:failureaccess:1.0.2",
+        "com.google.guava:guava:33.4.0-jre",
+        "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+        "com.google.j2objc:j2objc-annotations:3.0.0",
+        "eu.aylett:gradle-plugins:0.5.2",
+        "org.checkerframework:checker-qual:3.43.0",
+        "org.jetbrains.kotlin:kotlin-bom:2.0.20",
+      )
+    assertThat(lockEntries, contains(expected.map { startsWith(it) }))
+  }
+
+  @Test
+  fun `can update dependencies from a subproject via a platform subproject`() {
+    val buildProject = subproject("build")
+    buildProject.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+
+      dependencies {
+        implementation(platform(project(":platform")))
+        implementation("eu.aylett:gradle-plugins:0.5.2")
+      }
+      """.trimIndent(),
+    )
+
+    val platform = subproject("platform")
+
+    platform.resolve("build.gradle").writeText(
+      """
+      plugins {
+          id 'java-platform'
+          id 'eu.aylett.lock-dependencies'
+      }
+
+      repositories {
+        mavenCentral()
+      }
+      """.trimIndent(),
+    )
+
+    lockFile.writeText(
+      """
+      # Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.
+
+      eu.aylett:gradle-plugins:0.4.0 (requested)
+      """.trimIndent(),
+    )
+
+    run("writeVersionsLocks")
+
+    assertThat(result.task(":platform:writeVersionsLocks")!!.outcome, `is`(TaskOutcome.SUCCESS))
+    assertThat(lockFile, anExistingFile())
+    assertThat(lockFileLines.first(), startsWith("#"))
+
+    val expected =
+      listOf(
+        "com.google.code.findbugs:jsr305:3.0.2",
+        "com.google.errorprone:error_prone_annotations:2.36.0",
+        "com.google.guava:failureaccess:1.0.2",
+        "com.google.guava:guava:33.4.0-jre",
+        "com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava",
+        "com.google.j2objc:j2objc-annotations:3.0.0",
+        "eu.aylett:gradle-plugins:0.5.2",
+        "org.checkerframework:checker-qual:3.43.0",
+        "org.jetbrains.kotlin:kotlin-bom:2.0.20",
+      )
+    assertThat(lockEntries, contains(expected.map { startsWith(it) }))
+  }
+}

--- a/src/main/kotlin/eu/aylett/gradle/extensions/BaseExtension.kt
+++ b/src/main/kotlin/eu/aylett/gradle/extensions/BaseExtension.kt
@@ -18,4 +18,9 @@ package eu.aylett.gradle.extensions
 
 import org.gradle.api.plugins.ExtensionAware
 
+/**
+ * Root extension added by [eu.aylett.gradle.plugins.BasePlugin] under the `aylett` name.
+ *
+ * Other convention plugins attach their own nested extensions to this for user configuration.
+ */
 abstract class BaseExtension : ExtensionAware

--- a/src/main/kotlin/eu/aylett/gradle/extensions/JvmConventionExtension.kt
+++ b/src/main/kotlin/eu/aylett/gradle/extensions/JvmConventionExtension.kt
@@ -18,6 +18,13 @@ package eu.aylett.gradle.extensions
 
 import org.gradle.api.provider.Property
 
+/**
+ * Configuration options for the [eu.aylett.gradle.plugins.conventions.JvmConvention] plugin.
+ */
 interface JvmConventionExtension {
+  /**
+   * The target Java toolchain version to use for compilation and testing.
+   * Defaults to 21 unless overridden.
+   */
   val jvmVersion: Property<Int>
 }

--- a/src/main/kotlin/eu/aylett/gradle/gitversion/GitVersionPlugin.kt
+++ b/src/main/kotlin/eu/aylett/gradle/gitversion/GitVersionPlugin.kt
@@ -22,8 +22,16 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.apply
 
+/**
+ * Plugin that exposes git-derived version information to builds.
+ *
+ * Adds a `versions` extension providing `gitVersion {}` and `versionDetails {}` Groovy-closure APIs,
+ * sets Gradle extra properties `gitVersion` and `versionDetails` for easy access, and registers a
+ * `printVersion` task for convenience.
+ */
 @Suppress("unused")
 class GitVersionPlugin : Plugin<Project> {
+  /** Applies the plugin and wires up the versioning extension, properties, and tasks. */
   override fun apply(project: Project) {
     project.pluginManager.apply(BasePlugin::class)
     val versionCacheService =

--- a/src/main/kotlin/eu/aylett/gradle/plugins/BasePlugin.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/BasePlugin.kt
@@ -20,7 +20,17 @@ import eu.aylett.gradle.extensions.BaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+/**
+ * Base plugin that registers the root [eu.aylett.gradle.extensions.BaseExtension] under the `aylett` name.
+ *
+ * This is applied automatically by higher-level plugins in this module; you typically don't need to
+ * apply it directly.
+ */
 class BasePlugin : Plugin<Project> {
+  /**
+   * Creates the `aylett` extension on the target project, which is used by other convention plugins
+   * to expose configuration options.
+   */
   override fun apply(target: Project) {
     target.extensions.create("aylett", BaseExtension::class.java)
   }

--- a/src/main/kotlin/eu/aylett/gradle/plugins/conventions/Conventions.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/conventions/Conventions.kt
@@ -19,7 +19,14 @@ package eu.aylett.gradle.plugins.conventions
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
+/**
+ * Aggregates and applies all aylett.eu build conventions to a project.
+ *
+ * This plugin applies [BomAlignmentConvention], [IDESupportConvention], and [JvmConvention]
+ * to provide a sensible baseline for typical JVM builds.
+ */
 class Conventions : Plugin<Project> {
+  /** Applies the convention plugins to the target project. */
   override fun apply(target: Project) {
     target.pluginManager.run {
       apply(BomAlignmentConvention::class.java)

--- a/src/main/kotlin/eu/aylett/gradle/plugins/conventions/IDESupportConvention.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/conventions/IDESupportConvention.kt
@@ -43,6 +43,7 @@ import org.gradle.plugins.ide.idea.model.IdeaModel
  * ```
  */
 class IDESupportConvention : Plugin<Project> {
+  /** Applies IDEA configuration to download sources and Javadoc for dependencies. */
   override fun apply(target: Project) {
     target.pluginManager.apply("idea")
     target.extensions.getByType(IdeaModel::class).module {

--- a/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/DependencyLockPlugin.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/DependencyLockPlugin.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package eu.aylett.gradle.plugins.dependencies
+
+import eu.aylett.gradle.plugins.BasePlugin
+import eu.aylett.gradle.plugins.dependencies.VersionsLocksExtension.Companion.ALL_DEPENDENCIES
+import eu.aylett.gradle.plugins.dependencies.VersionsLocksExtension.Companion.ALL_DEPENDENCIES_CLASSPATH
+import eu.aylett.gradle.plugins.dependencies.VersionsLocksExtension.Companion.LOCK_CONSTRAINTS
+import eu.aylett.gradle.plugins.dependencies.VersionsLocksExtension.Companion.OTHER_PROJECT_DEPENDENCIES
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.plugins.JavaPlatformPlugin
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.register
+import org.gradle.kotlin.dsl.withType
+import org.intellij.lang.annotations.Language
+import java.nio.file.Files
+import javax.inject.Inject
+
+/**
+ * A plugin that enables version locking for dependency declarations in a Gradle project.
+ * It enforces constraints based on a predefined "versions.lock" file, generates this file
+ * when needed, and integrates version locking into the project's dependency resolution process.
+ *
+ * Key functionalities:
+ * - Registers configurations for managing all dependencies and for resolving classpath dependencies.
+ * - Configures a write task (`writeVersionsLocks`) to generate a "versions.lock" file, capturing
+ *   the resolved versions of dependencies.
+ * - Applies constraints defined in the "versions.lock" file to the `lockConstraints` configuration.
+ * - Ensures the `api` configuration in Java platform projects extends the `lockConstraints`
+ *   configuration when the plugin is applied.
+ * - Coordinates dependency locking across multiple projects in a build via the DependencySupplierService.
+ */
+class DependencyLockPlugin
+  @Inject
+  constructor(
+    private var dependencyHandler: DependencyHandler,
+    project: Project,
+  ) : Plugin<Project> {
+    /**
+     * Matches the dependency coordinate at the start of a non-comment, non-empty line in `versions.lock`.
+     * The expected form is `group:artifact:version`.
+     */
+    @Language("RegExp")
+    private val lockLinePattern: Regex = Regex("^[^ :]+:[^ :]+:[^ :]+")
+
+    private val allDependenciesConfiguration =
+      project.configurations
+        .consumable(
+          ALL_DEPENDENCIES,
+        ).get()
+    private val allDependenciesClasspath =
+      project.configurations.resolvable(ALL_DEPENDENCIES_CLASSPATH).get()
+    private val lockConstraints = project.configurations.dependencyScope(LOCK_CONSTRAINTS).get()
+    private val otherProjectDependencies =
+      project.configurations.dependencyScope(OTHER_PROJECT_DEPENDENCIES).get()
+
+    /**
+     * Applies the dependency lock plugin to the given project.
+     *
+     * - Registers internal configurations used to collect all dependencies and a resolvable classpath.
+     * - Creates the `writeVersionsLocks` task that writes a lock file at the root of the build.
+     * - On Java Platform projects, enables the write task and converts the lock file entries to constraints
+     *   that are added to the platform's `api` configuration.
+     */
+    override fun apply(target: Project) {
+      target.plugins.apply(BasePlugin::class.java)
+      target.extensions.create<VersionsLocksExtension>("versionsLocks", target)
+
+      val dependencySupplier = DependencySupplierService.getDependencySupplierService(target)
+      dependencySupplier.get().registerProject(target.isolated)
+
+      target.configurations.configureEach {
+        if (!this.hierarchy.contains(allDependenciesConfiguration) && !this.isCanBeResolved) {
+          allDependenciesConfiguration.extendsFrom(this)
+        }
+        if (!this.hierarchy.contains(allDependenciesClasspath) && !this.isCanBeConsumed) {
+          allDependenciesClasspath.extendsFrom(this)
+        }
+      }
+
+      val versionsLockFile =
+        target.isolated.rootProject.projectDirectory
+          .file("versions.lock")
+      val writeVersionsLocks =
+        target.tasks.register<WriteVersionsLocksTask>("writeVersionsLocks") {
+          enabled = false
+          output.set(versionsLockFile)
+          dependsOn(allDependenciesClasspath)
+        }
+
+      if (versionsLockFile.asFile.exists()) {
+        Files.readAllLines(versionsLockFile.asFile.toPath()).forEach {
+          if (it.isBlank() || it.startsWith("#")) {
+            return@forEach
+          }
+          val matcher =
+            lockLinePattern.find(it)
+              ?: throw IllegalStateException("Invalid lock file dependencies reading $it")
+
+          val dependencyNotation = matcher.value
+          lockConstraints.dependencyConstraints.add(
+            dependencyHandler.constraints.create(
+              dependencyNotation,
+            ),
+          )
+        }
+      }
+
+      target.plugins.withType<JavaPlatformPlugin> {
+        writeVersionsLocks.get().enabled = true
+
+        dependencySupplier.get().knownProjects.configureEach {
+          if (this.path != target.path) {
+            otherProjectDependencies.dependencies.add(
+              dependencyHandler.project(
+                mapOf(
+                  "path" to this.path,
+                  "configuration" to ALL_DEPENDENCIES,
+                ),
+              ),
+            )
+          }
+        }
+
+        target.configurations.named("api").configure {
+          extendsFrom(lockConstraints)
+        }
+      }
+    }
+  }

--- a/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/DependencySupplierService.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/DependencySupplierService.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package eu.aylett.gradle.plugins.dependencies
+
+import org.gradle.api.DomainObjectSet
+import org.gradle.api.Project
+import org.gradle.api.project.IsolatedProject
+import org.gradle.api.provider.Provider
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+
+/**
+ * A build service used to coordinate dependency collection across all projects in a multi-project build.
+ *
+ * The service tracks all known projects so that the dependency locking plugin can build a complete
+ * view of external dependencies before writing the lock file or applying constraints on a platform project.
+ */
+abstract class DependencySupplierService : BuildService<BuildServiceParameters.None> {
+  /** Set of projects participating in dependency collection. */
+  abstract val knownProjects: DomainObjectSet<IsolatedProject>
+
+  /** Registers a project with the service. */
+  fun registerProject(project: IsolatedProject) {
+    knownProjects.add(project)
+  }
+
+  companion object {
+    /** Gets or creates the shared [DependencySupplierService] instance for the current build. */
+    fun getDependencySupplierService(project: Project): Provider<DependencySupplierService> =
+      project.gradle
+        .sharedServices
+        .registerIfAbsent(
+          "DependencySupplierService",
+          DependencySupplierService::class.java,
+        ) {}
+  }
+}

--- a/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/VersionsLocksExtension.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/VersionsLocksExtension.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package eu.aylett.gradle.plugins.dependencies
+
+import org.gradle.api.Project
+import org.gradle.api.file.RegularFile
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Provider
+
+abstract class VersionsLocksExtension(
+  private var project: Project,
+) : ExtensionAware {
+  val versionsLockFile: Provider<RegularFile> =
+    project.provider {
+      project.isolated.projectDirectory.file("versions.lock")
+    }
+
+  fun extendAllConfigurations() {
+    val lockConstraints = project.configurations.getByName(LOCK_CONSTRAINTS)
+
+    project.configurations.configureEach {
+      if (!this.hierarchy.contains(lockConstraints)) {
+        if (this.isCanBeDeclared) {
+          this.extendsFrom(lockConstraints)
+        }
+      }
+    }
+  }
+
+  fun enableLockWriting() {
+    project.tasks.named("writeVersionsLocks").configure {
+      this.enabled = true
+    }
+  }
+
+  companion object {
+    const val ALL_DEPENDENCIES: String = "allDependencies"
+    const val ALL_DEPENDENCIES_CLASSPATH: String = "allDependenciesClasspath"
+    const val LOCK_CONSTRAINTS: String = "lockConstraints"
+    const val OTHER_PROJECT_DEPENDENCIES: String = "otherProjectDependencies"
+  }
+}

--- a/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/WriteVersionsLocksTask.kt
+++ b/src/main/kotlin/eu/aylett/gradle/plugins/dependencies/WriteVersionsLocksTask.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.plugins.dependencies
+
+import eu.aylett.gradle.plugins.dependencies.VersionsLocksExtension.Companion.ALL_DEPENDENCIES_CLASSPATH
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.artifacts.result.ComponentSelectionCause
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.util.stream.Collectors
+import javax.inject.Inject
+
+@CacheableTask
+/**
+ * Task that writes a dependency versions lock file for the current build.
+ *
+ * This task resolves the full dependency graph from the `allDependenciesClasspath` configuration and
+ * writes a `versions.lock` file with one line per external module in the form
+ * `group:artifact:version (…resolution reasons…)`.
+ */
+abstract class WriteVersionsLocksTask : DefaultTask() {
+  /** The destination file for the generated lock. Typically `<root>/versions.lock`. */
+  @get:OutputFile
+  abstract val output: RegularFileProperty
+
+  /**
+   * Project configurations used by the task. The task reads dependencies from
+   * the `allDependenciesClasspath` configuration.
+   */
+  @get:Inject
+  abstract val configurations: ConfigurationContainer
+
+  /** Resolves dependencies and writes the lock file to [output]. */
+  @TaskAction
+  fun writeLockFile() {
+    val allDependenciesClasspath = configurations.getByName(ALL_DEPENDENCIES_CLASSPATH)
+    allDependenciesClasspath.resolve()
+    val allDependencies = allDependenciesClasspath.incoming.resolutionResult.allDependencies
+    val depMap =
+      allDependencies
+        .stream()
+        .mapMulti { it, consumer ->
+          if (it is ResolvedDependencyResult) {
+            val selected = it.selected
+            val moduleVersion = selected.moduleVersion
+            if (selected.id !is ProjectComponentIdentifier && moduleVersion != null &&
+              moduleVersion.name.isNotEmpty() &&
+              moduleVersion.group.isNotEmpty() &&
+              moduleVersion.version.isNotEmpty()
+            ) {
+              consumer.accept(Pair(selected, moduleVersion))
+            }
+          }
+        }.collect(
+          Collectors.toMap({ Pair(it.second.group, it.second.name) }, { it }, { a, _ -> a }),
+        )
+    output.get().asFile.bufferedWriter().use { writer ->
+      writer.appendLine(
+        "# Run ./gradlew writeVersionsLocks to regenerate this file. Blank lines are to minimize merge conflicts.",
+      )
+      depMap.values
+        .stream()
+        .sorted(compareBy({ it.second.group }, { it.second.name }))
+        .map {
+          "\n${it.second.group}:${it.second.name}:${it.second.version} (${
+            it.first.selectionReason.descriptions.joinToString(
+              ", ",
+            ) { it.description }
+          })"
+        }.forEachOrdered { writer.appendLine(it) }
+    }
+  }
+}

--- a/src/test/kotlin/eu/aylett/gradle/plugins/dependencies/DependencyLockPluginTest.kt
+++ b/src/test/kotlin/eu/aylett/gradle/plugins/dependencies/DependencyLockPluginTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.plugins.dependencies
+
+import eu.aylett.gradle.matchers.hasPlugin
+import org.gradle.api.plugins.JavaPlatformPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.notNullValue
+import org.junit.jupiter.api.Test
+
+class DependencyLockPluginTest {
+  @Test
+  fun `can apply plugin`() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+
+    assertThat(project, hasPlugin("eu.aylett.lock-dependencies"))
+  }
+
+  @Test
+  fun `registers writeVersionsLocks task`() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+
+    assertThat(project.tasks.findByName("writeVersionsLocks"), notNullValue())
+  }
+
+  @Test
+  fun `writeVersionsLocks task is disabled by default`() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+
+    val task = project.tasks.findByName("writeVersionsLocks")
+    assertThat(task?.enabled, equalTo(false))
+  }
+
+  @Test
+  fun `can apply plugin to multiple projects`() {
+    val rootProject = ProjectBuilder.builder().build()
+    val childProject = ProjectBuilder.builder().withParent(rootProject).build()
+
+    rootProject.pluginManager.apply(DependencyLockPlugin::class.java)
+    childProject.pluginManager.apply(DependencyLockPlugin::class.java)
+    childProject.pluginManager.apply(JavaPlatformPlugin::class.java)
+
+    assertThat(rootProject, hasPlugin("eu.aylett.lock-dependencies"))
+    assertThat(childProject, hasPlugin("eu.aylett.lock-dependencies"))
+
+    val child = childProject.tasks.getByName("writeVersionsLocks")
+    assertThat(child.enabled, equalTo(true))
+    val parent = rootProject.tasks.getByName("writeVersionsLocks")
+    assertThat(parent.enabled, equalTo(false))
+  }
+
+  @Test
+  fun `sets the api configuration to depend on lock file in platform projects`() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+    project.pluginManager.apply(JavaPlatformPlugin::class.java)
+
+    val apiConfig = project.configurations.getByName("api")
+    val lockFileConfig = project.configurations.getByName("lockConstraints")
+
+    assertThat(apiConfig.extendsFrom, hasItem(lockFileConfig))
+  }
+}

--- a/src/test/kotlin/eu/aylett/gradle/plugins/dependencies/VersionsLocksExtensionTest.kt
+++ b/src/test/kotlin/eu/aylett/gradle/plugins/dependencies/VersionsLocksExtensionTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Andrew Aylett
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.aylett.gradle.plugins.dependencies
+
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class VersionsLocksExtensionTest {
+  @Test
+  fun getVersionsLockFile() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+
+    val extension = project.extensions.getByType(VersionsLocksExtension::class.java)
+    val lockFile = extension.versionsLockFile
+    assertThat(lockFile.get().asFile.name, equalTo("versions.lock"))
+  }
+
+  @Test
+  fun extendAllConfigurations() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(JavaPlugin::class.java)
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+
+    val extension = project.extensions.getByType(VersionsLocksExtension::class.java)
+    extension.extendAllConfigurations()
+
+    assertThat(
+      project.configurations.getByName("implementation").hierarchy,
+      Matchers.hasItem(project.configurations.getByName("lockConstraints")),
+    )
+    assertThat(
+      project.configurations.getByName("testImplementation").hierarchy,
+      Matchers.hasItem(project.configurations.getByName("lockConstraints")),
+    )
+  }
+
+  @Test
+  fun enableLockWriting() {
+    val project = ProjectBuilder.builder().build()
+    project.pluginManager.apply(DependencyLockPlugin::class.java)
+    val task = project.tasks.getByName("writeVersionsLocks")
+
+    assertThat(task.enabled, equalTo(false))
+
+    val extension = project.extensions.getByType(VersionsLocksExtension::class.java)
+    extension.enableLockWriting()
+
+    assertThat(task.enabled, equalTo(true))
+  }
+}


### PR DESCRIPTION
I tried to make the lock format compatible with gradle-consistent-versions from Palantir, so tools (like Renovate) that can bump that can also bump this.